### PR TITLE
Fix spelling mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ are resolved:
 ```go
 msgType, err := hyperpb.CompileFileDescriptor(
     schema,
-    mesasgeName,
+    messageName,
     hyperpb.WithExtensionsFromTypes(typeRegistry),
     // Additional options...
 )


### PR DESCRIPTION
Unsure why GitHub modified the last line. I suppose it added a newline automatically.