### PR TITLE
Make sure that everything builds with `-race`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
         # We use macos here because those are the only ARM runners available
         # to private repositories.
         os: [ubuntu-latest, macos-15]
-        tags: ["", debug]
+        mode: [fast, debug, race]
         go-version: [1.24.x]
     runs-on: ${{ matrix.os }}
 
@@ -39,16 +39,25 @@ jobs:
           restore-keys: "${{ runner.os }}-hyperpb-ci-"
 
       - name: Check Generated Files
-        if: ${{ matrix.tags == '' }}
+        if: ${{ matrix.mode == fast }}
         run: |
           make generate
           make checkgenerate
 
       - name: Test
-        run: make test TAGS=${{ matrix.tags }} 
+        if: ${{ matrix.mode == fast }}
+        run: make test
+
+      - name: Test Debug
+        if: ${{ matrix.mode == debug }}
+        run: make test TAGS=debug
+
+      - name: Test Race
+        if: ${{ matrix.mode == race }}
+        run: make test HYPERTESTFLAGS=-race
 
       - name: Benchmark
-        if: ${{ matrix.tags == '' }}
+        if: ${{ matrix.mode == fast }}
         run: make bench BENCHMARK="B/^descriptor.yaml" 
 
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,25 +39,25 @@ jobs:
           restore-keys: "${{ runner.os }}-hyperpb-ci-"
 
       - name: Check Generated Files
-        if: ${{ matrix.mode == fast }}
+        if: ${{ matrix.mode == 'fast' }}
         run: |
           make generate
           make checkgenerate
 
       - name: Test
-        if: ${{ matrix.mode == fast }}
+        if: ${{ matrix.mode == 'fast' }}
         run: make test
 
       - name: Test Debug
-        if: ${{ matrix.mode == debug }}
+        if: ${{ matrix.mode == 'debug' }}
         run: make test TAGS=debug
 
       - name: Test Race
-        if: ${{ matrix.mode == race }}
+        if: ${{ matrix.mode == 'race' }}
         run: make test HYPERTESTFLAGS=-race
 
       - name: Benchmark
-        if: ${{ matrix.mode == fast }}
+        if: ${{ matrix.mode == 'fast' }}
         run: make bench BENCHMARK="B/^descriptor.yaml" 
 
   lint:

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,14 @@ EXEC_ENV ?= GOOS=$(GOOS) GOARCH=$(GOARCH) GOAMD64=$(GOAMD64) GOARM64=$(GOARM64) 
 unexport GOOS
 unexport GOARCH
 
+HYPERTESTFLAGS ?=
+TESTFLAGS ?=
+BENCHFLAGS ?= -test.benchmem
+
 GO ?= go
 GO_HOST := $(HOST_TARGET) $(GO)
 GO := $(EXEC_ENV) $(GO)
-TEST := $(EXEC_ENV) $(BIN)/hypertest -o $(TESTS)
+TEST := $(EXEC_ENV) $(BIN)/hypertest -o $(TESTS) $(HYPERTESTFLAGS)
 
 TAGS ?= ""
 REMOTE ?= ""
@@ -66,8 +70,6 @@ else
 	PKGS := $(PKG)
 endif
 PKG ?= .
-TESTFLAGS ?=
-BENCHFLAGS ?= -test.benchmem
 
 .PHONY: help
 help: ## Describe useful make targets

--- a/internal/tdp/thunks/repeated.go
+++ b/internal/tdp/thunks/repeated.go
@@ -268,6 +268,7 @@ func parseRepeatedVarint[T tdp.Int](p1 vm.P1, p2 vm.P2) (vm.P1, vm.P2) {
 }
 
 //go:nosplit
+//go:norace // Race instrumentation causes this function to fail the nosplit check.
 //hyperpb:stencil parsePackedVarint8 parsePackedVarint[uint8]
 //hyperpb:stencil parsePackedVarint32 parsePackedVarint[uint32]
 //hyperpb:stencil parsePackedVarint64 parsePackedVarint[uint64]

--- a/internal/tdp/thunks/stencils.go
+++ b/internal/tdp/thunks/stencils.go
@@ -8342,6 +8342,7 @@ func parseRepeatedVarint64(p1 vm.P1, p2 vm.P2) (vm.P1, vm.P2) {
 }
 
 //go:nosplit
+//go:norace // Race instrumentation causes this function to fail the nosplit check.
 func parsePackedVarint8(p1 vm.P1, p2 vm.P2) (vm.P1, vm.P2) {
 	_ = parsePackedVarint[uint8]
 	var n int
@@ -8471,6 +8472,7 @@ func parsePackedVarint8(p1 vm.P1, p2 vm.P2) (vm.P1, vm.P2) {
 }
 
 //go:nosplit
+//go:norace // Race instrumentation causes this function to fail the nosplit check.
 func parsePackedVarint32(p1 vm.P1, p2 vm.P2) (vm.P1, vm.P2) {
 	_ = parsePackedVarint[uint32]
 	var n int
@@ -8600,6 +8602,7 @@ func parsePackedVarint32(p1 vm.P1, p2 vm.P2) (vm.P1, vm.P2) {
 }
 
 //go:nosplit
+//go:norace // Race instrumentation causes this function to fail the nosplit check.
 func parsePackedVarint64(p1 vm.P1, p2 vm.P2) (vm.P1, vm.P2) {
 	_ = parsePackedVarint[uint64]
 	var n int

--- a/internal/tools/hypertest/main.go
+++ b/internal/tools/hypertest/main.go
@@ -35,6 +35,7 @@ var (
 	profile  = flag.Bool("profile", false, "whether to collect CPU profiles")
 	remote   = flag.String("remote", "", "SSH remote to run tests at")
 	checkptr = flag.Bool("checkptr", false, "build with checkptr (crappy asan) instrumentation")
+	race     = flag.Bool("race", false, "build with -race")
 
 	benchCsv   = flag.String("csv", "", "file for benchmark csv output")
 	benchTable = flag.String("table", "", "file for benchmark table output")
@@ -63,6 +64,7 @@ func run() error {
 		tags:     *tags,
 		profile:  *profile,
 		checkptr: *checkptr,
+		race:     *race,
 		args:     flag.Args(),
 	}
 


### PR DESCRIPTION
There is no concurrency in `hyperpb`, but users might decide to build with `-race`, so we should make sure that we can build (and pass) with the race detector on; this is similar to how tests are run with `-d=checkptr`.

However, building with `-race` fails the nosplit check. This is easily fixed by disabling race instrumentation in one function (which requires generalizing the nosplit handling code in `hyperstencil`).