### PR TITLE
Add an explicit architecture support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,18 @@ these `amd64` and `arm64`). The library will not build on other architectures,
 and PRs to add new architectures without a way to run tests for them in CI will
 be rejected.
 
-Support for 32-bit targets is unlikely to happen; `hyperpb` assumes a 64-bit
-general-purpose register width, and attempting to tune for a 32-bit register
-size will require a parallel implementation of the parser VM.
+Support for 32-bit targets is unlikely to happen, even if we have test runners.
+`hyperpb` assumes a 64-bit general-purpose register width, and attempting to
+tune for a 32-bit register size will require a 32-bit re-implementation of the
+parser VM.
+
+Similarly, we assume little-endian in many places for performance, particularly
+because Protobuf's wire format is little-endian. Getting big-endian support will
+be a lot of work and is unlikely to perform anywhere close to little-endian.
+
+If you would like to try to use an architecture that we don't support, build
+with the `hyperpb.unsupported` tag. If it breaks, you get to keep both pieces:
+which is to say, issues stemming from use of this build tag will be closed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,17 @@ func (c *requestContext) Handle(req Request) {
 `v1`. It currently implements all Protobuf language constructs. It does not
 implement mutation of parsed messages, however.
 
+### Supported Targets
+
+`hyperpb` is currently only supported on 64-bit x86 and ARM targets (Go calls
+these `amd64` and `arm64`). The library will not build on other architectures,
+and PRs to add new architectures without a way to run tests for them in CI will
+be rejected.
+
+Support for 32-bit targets is unlikely to happen; `hyperpb` assumes a 64-bit
+general-purpose register width, and attempting to tune for a 32-bit register
+size will require a parallel implementation of the parser VM.
+
 ## Contributing
 
 For a detailed explanation of the implementation details of `hyperpb`, see

--- a/doc.go
+++ b/doc.go
@@ -154,6 +154,11 @@
 // v1. It currently implements all Protobuf language constructs. It does not
 // implement mutation of parsed messages, however.
 //
+// hyperpb is currently only supported on 64-bit x86 and ARM targets (Go calls
+// these amd64 and arm64). The library will not build on other architectures,
+// and PRs to add new architectures without a way to run tests for them in CI will
+// be rejected.
+//
 // [the UPB project]: https://github.com/protocolbuffers/protobuf/tree/main/upb
 package hyperpb
 

--- a/internal/xunsafe/support/unsupported.go
+++ b/internal/xunsafe/support/unsupported.go
@@ -18,6 +18,6 @@ package support
 
 /*
 // cgo is the only real option we have for triggering a custom compiler error.
-#error "unsupported architecture; hyperpb only supports x86_64 and aarch64"
+#error "unsupported architecture; see https://github.com/bufbuild/hyperpb-go/blob/main/README.md#supported-targets"
 */
 import "C"

--- a/internal/xunsafe/support/unsupported.go
+++ b/internal/xunsafe/support/unsupported.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(amd64 || arm64)
+//go:build !(amd64 || arm64 || hyperpb.unsupported)
 
 package support
 


### PR DESCRIPTION
We only support 64-bit x86 and ARM. This is already automatically enforced (builds on other archs won't work) but this is not documented.

I've also added a way for people who want to hurt themselves to turn the check off, and a solemn warning about the `hyperpb.unsupported` tag.