### PR TITLE
Add nocheckptr to ByteAdd

### DIFF
--- a/internal/xunsafe/untyped.go
+++ b/internal/xunsafe/untyped.go
@@ -19,6 +19,17 @@ import "unsafe"
 // ByteAdd adds the given offset to p, without scaling.
 //
 // It also throws in a cast for free.
+//
+// This is used in the VM to decode varints, but the VM unconditionally loads 8
+// bytes for performance reasons. In practice, this is not a problem - if we
+// end up loading data from another object, that data would be masked off, or
+// handled by length checks later on.
+//
+// checkptr does not like us doing this. It could be fixed with a bounds check
+// here, but that would add an unnecessary branch in the hottest part of the VM
+// without changing observable behavior.
+//
+//go:nocheckptr
 func ByteAdd[T any, P ~*E, E any, I Int](p P, n I) *T {
 	return (*T)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + uintptr(n)))
 }


### PR DESCRIPTION
Ran into the following error while trying to use this:

```
fatal error: checkptr: converted pointer straddles multiple allocations
```