### PR TITLE
Update to Go 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 jobs:
   ci:
-    name: "Tests and Benchmarks (${{ matrix.os }}, ${{ matrix.mode }}, ${{ matrix.go-version.name }})"
+    name: "Tests and Benchmarks (${{ matrix.os }}, ${{ matrix.mode }}, go:${{ matrix.go-version.name }})"
     strategy:
       matrix:
         # We use macos here because those are the only ARM runners available
@@ -70,7 +70,7 @@ jobs:
         run: make bench BENCHMARK="B/^descriptor.yaml"
 
   lint:
-    name: "Lint (${{ matrix.go-version.name }})"
+    name: "Lint (go:${{ matrix.go-version.name }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 jobs:
   ci:
-    name: "Tests and Benchmarks"
+    name: "Tests and Benchmarks (${{ matrix.os }}, ${{ matrix.mode }}, ${{ matrix.go-version.name }})"
     strategy:
       matrix:
         # We use macos here because those are the only ARM runners available
@@ -70,7 +70,7 @@ jobs:
         run: make bench BENCHMARK="B/^descriptor.yaml"
 
   lint:
-    name: Lint
+    name: "Lint (${{ matrix.go-version.name }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,19 +12,23 @@ permissions:
   contents: read
 jobs:
   ci:
-    name: "Tests and Benchmarks (${{ matrix.os }}, ${{ matrix.mode }}, go:${{ matrix.go-version.name }})"
+    name: "Tests and Benchmarks (${{ matrix.os.name }}, ${{ matrix.mode }}, go:${{ matrix.go-version.name }})"
     strategy:
       matrix:
         # We use macos here because those are the only ARM runners available
         # to private repositories.
-        os: [ubuntu-latest, macos-15]
+        os:
+          - name: ubuntu
+            version: ubuntu-latest
+          - name: macos
+            version: macos-latest
         mode: [fast, debug, race, unopt]
         go-version:
           - name: latest
             version: 1.26.x
           - name: previous
             version: 1.25.x
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.version }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,11 @@ jobs:
         # to private repositories.
         os: [ubuntu-latest, macos-15]
         mode: [fast, debug, race, unopt]
-        go-version: [1.24.x, 1.25.x]
+        go-version:
+          - name: latest
+            version: 1.26.x
+          - name: previous
+            version: 1.25.x
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -29,7 +33,7 @@ jobs:
 
       - name: Install Go
         uses: actions/setup-go@v5
-        with: {go-version: "${{ matrix.go-version }}"}
+        with: {go-version: "${{ matrix.go-version.version }}"}
 
       - name: Cache
         uses: actions/cache@v4
@@ -70,7 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version:
+          - name: latest
+            version: 1.26.x
+          - name: previous
+            version: 1.25.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -78,8 +86,8 @@ jobs:
 
       - name: Install Go
         uses: actions/setup-go@v5
-        with: {go-version: "${{ matrix.go-version }}"}
+        with: {go-version: "${{ matrix.go-version.version }}"}
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
-        with: {version: v2.4.0} # Keep in sync with the Makefile.
+        uses: golangci/golangci-lint-action@v9
+        with: {version: v2.11.4} # Keep in sync with the Makefile.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,7 @@ linters:
     - exhaustive                # Seemingly made of false positives.
     - exhaustruct               # Listing every field is not idiomatic.
     - forcetypeassert           # Covered by errcheck.
+    - goprintffuncname          # Our printf-like helpers take a leading op argument.
 
     - gochecknoglobals          # Several places require globals for performance (e.g. sync.Pool).
     - gochecknoinits            # Ditto. ^
@@ -111,6 +112,8 @@ linters:
       - { path: '.*', text: 'G404: Use of weak random number generator.*' }
       - { path: '.*', text: 'G306: Expect WriteFile permissions to be 0600 or less.*' }
       - { path: '.*', text: 'G204: Subprocess launched with a potential tainted input or cmd arguments' }
+      # Our dev tools intentionally operate on user-provided paths.
+      - { path: '.*', text: 'G703: Path traversal via taint analysis' }
       # We call this parameter `t`.
       - { path: '.*', text: 'parameter testing.TB should have name tb' }
 

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ export GOBIN := $(abspath $(BIN))
 COPYRIGHT_YEARS := 2025
 LICENSE_IGNORE := testdata/
 
-GO_VERSION := go1.25.0
+GO_VERSION := go1.26.0
 BUF_VERSION := v1.56.0 # Keep in sync w/ .github/workflows/buf.yaml.
-LINT_VERSION := v2.4.0 # Keep in sync w/ .github/workflows/ci.yaml.
+LINT_VERSION := v2.11.4 # Keep in sync w/ .github/workflows/ci.yaml.
 
 GOOS_HOST := $(shell go env GOOS)
 GOARCH_HOST := $(shell go env GOARCH)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module buf.build/go/hyperpb
 
-go 1.24.0
+go 1.25.0
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0

--- a/internal/scc/scc.go
+++ b/internal/scc/scc.go
@@ -70,7 +70,7 @@ func (d *DAG[Node]) ForNode(node Node) *Component[Node] {
 	return &d.components[idx]
 }
 
-// To range over the components some node depends on.
+// Topological returns an iterator over the components in topological order.
 func (d *DAG[Node]) Topological() iter.Seq[*Component[Node]] {
 	return func(yield func(*Component[Node]) bool) {
 		for i := range d.components {

--- a/internal/swiss/table.go
+++ b/internal/swiss/table.go
@@ -234,7 +234,7 @@ func (t *Table[K, V]) LookupFunc(k []byte, extract func(K) []byte) *V {
 	return t.values().Get(idx)
 }
 
-// insert returns a pointer to the slot for the given key. extract is an
+// Insert returns a pointer to the slot for the given key. extract is an
 // optional function for extracting variable-length key material from keys
 // in the table.
 //

--- a/internal/tdp/compiler/compile.go
+++ b/internal/tdp/compiler/compile.go
@@ -37,7 +37,7 @@ import (
 	"buf.build/go/hyperpb/internal/xunsafe"
 )
 
-// CompileOption is a configuration setting for [Compile].
+// Options is the configuration for [Compile].
 type Options struct {
 	Profile    profile.Profile
 	Extensions ExtensionResolver

--- a/internal/tdp/compiler/linker/sym.go
+++ b/internal/tdp/compiler/linker/sym.go
@@ -65,7 +65,7 @@ func (s *Sym) Push(v any) int {
 	return s.PushBytes(align, xunsafe.AnyBytes(v))
 }
 
-// Push appends raw bytes to this symbol, ensuring that it is correctly-aligned.
+// PushBytes appends raw bytes to this symbol, ensuring that it is correctly-aligned.
 //
 // Returns the offset of the pushed data.
 func (s *Sym) PushBytes(align int, data []byte) int {

--- a/internal/tdp/dynamic/message.go
+++ b/internal/tdp/dynamic/message.go
@@ -158,8 +158,8 @@ func (m *Message) Get(fd protoreflect.FieldDescriptor) protoreflect.Value {
 	return fd.Default()
 }
 
-// GetByIndex is like [Message.Get], but it takes a raw field index, performing
-// no bounds checks.
+// GetByIndexUnchecked is like [Message.Get], but it takes a raw field index,
+// performing no bounds checks.
 func (m *Message) GetByIndexUnchecked(n int) protoreflect.Value {
 	return m.Type().ByIndex(n).Get(unsafe.Pointer(m))
 }
@@ -201,7 +201,7 @@ func (m *Message) GetBit(n uint32) bool {
 	return word&mask != 0
 }
 
-// StBit sets the value of the nth bit from this message's bitset.
+// SetBit sets the value of the nth bit from this message's bitset.
 func (m *Message) SetBit(n uint32, flag bool) {
 	words := xunsafe.Cast[uint32](xunsafe.Add(m, 1))
 	word := xunsafe.Add(words, int(n)/32)
@@ -219,7 +219,7 @@ func (m *Message) Type() *tdp.Type {
 	return m.Shared.lib.AtOffset(m.TypeOffset)
 }
 
-// cold returns a pointer to the cold region, or nil if it hasn't been allocated.
+// Cold returns a pointer to the cold region, or nil if it hasn't been allocated.
 func (m *Message) Cold() *Cold {
 	if m.ColdIndex < 0 {
 		return nil

--- a/internal/tdp/profile/recorder.go
+++ b/internal/tdp/profile/recorder.go
@@ -129,7 +129,7 @@ func (r *Recorder) ForField(site Site) Field {
 
 // Dump dumps this recorder's profile.
 func (r *Recorder) Dump() string {
-	var ms []*metrics //nolint:prealloc // I literally can't!!!
+	var ms []*metrics
 	for _, v := range r.profiles.All() {
 		ms = append(ms, v)
 	}

--- a/internal/tdp/tag.go
+++ b/internal/tdp/tag.go
@@ -30,7 +30,7 @@ import (
 // message, but with the high bit of each byte cleared.
 type Tag uint64
 
-// encode encodes this field tag from the given number and type.
+// EncodeTag encodes a field tag from the given number and type.
 func EncodeTag(n protowire.Number, t protowire.Type) Tag {
 	var tag Tag
 	protowire.AppendTag(xunsafe.Bytes(&tag)[:0], n, t)
@@ -76,8 +76,8 @@ func (t Tag) Format(s fmt.State, verb rune) {
 	debug.Fprintf("%#x:%d:%d", uint64(t), n, ty).Format(s, verb)
 }
 
-// Returns whether this tag is "too large", i.e., if it has more than 32 bits
-// when decoded.
+// Overflows returns whether this tag is "too large", i.e., if it has more
+// than 32 bits when decoded.
 func (t Tag) Overflows() bool {
 	return bits.LeadingZeros64(uint64(t)) < (64 - 32 - 4)
 }

--- a/internal/tdp/type.go
+++ b/internal/tdp/type.go
@@ -54,9 +54,9 @@ type Type struct {
 	//    aforementioned field table.
 }
 
-// byIndex returns the nth byIndex (in byIndex number order) for this type.
+// ByIndex returns the nth field (in field number order) for this type.
 //
-// If n == 0 and this type has no fields, returns a byIndex with an invalid byIndex number.
+// If n == 0 and this type has no fields, returns a field with an invalid field number.
 //
 // This function does not perform bounds checks.
 func (t *Type) ByIndex(n int) *Field {

--- a/internal/tdp/vm/error.go
+++ b/internal/tdp/vm/error.go
@@ -22,7 +22,9 @@ import (
 
 const (
 	ErrorOk ErrorCode = iota
-	// These match the errors in protowire.
+
+	// The following errors match the errors in protowire.
+
 	ErrorTruncated
 	ErrorFieldNumber
 	ErrorOverflow

--- a/internal/tools/hyperdump/main.go
+++ b/internal/tools/hyperdump/main.go
@@ -133,7 +133,7 @@ func parseDump(data string) (fns []Func, err error) {
 		return arg
 	}
 
-	for _, line := range strings.Split(data, "\n") {
+	for line := range strings.SplitSeq(data, "\n") {
 		if line == "" {
 			continue
 		}

--- a/internal/tools/hyperdump/main.go
+++ b/internal/tools/hyperdump/main.go
@@ -323,11 +323,9 @@ func run(binary string) error {
 	// Annotate each function with jump labels.
 	wg := new(sync.WaitGroup)
 	for i := range fns {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			generateLabels(&fns[i])
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/tools/hyperstencil/main.go
+++ b/internal/tools/hyperstencil/main.go
@@ -324,7 +324,7 @@ func run() error {
 		mtime = info.ModTime()
 	}
 
-	var files []string //nolint:prealloc
+	var files []string
 	var newer bool
 	for _, dirent := range dir {
 		if dirent.Type().IsDir() ||

--- a/internal/tools/hyperstencil/main.go
+++ b/internal/tools/hyperstencil/main.go
@@ -368,9 +368,7 @@ func run() error {
 	// Stenciling isn't super fast; parallelizing it helps a lot.
 	decls := make([][]ast.Decl, len(files))
 	for i, path := range files {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
 			if err != nil {
 				ch <- fmt.Errorf("%s:%w", path, err)
@@ -439,10 +437,7 @@ func run() error {
 			*decls = make([]ast.Decl, len(directives))
 
 			for i, dir := range directives {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-
+				wg.Go(func() {
 					// Start by finding a func in file with this name.
 					generic := funcs[dir.Source]
 					stencil, err := makeStencil(dir, generic, &bases, &attrs)
@@ -453,9 +448,9 @@ func run() error {
 
 					// Finally, append stencil to the output file.
 					(*decls)[i] = stencil
-				}()
+				})
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/tools/hypertest/bench.go
+++ b/internal/tools/hypertest/bench.go
@@ -74,7 +74,7 @@ func parseBenchmarkOutput(stdout string) *benchReport {
 
 	var prev string
 	subtests := map[string]int{}
-	for _, line := range strings.Split(stdout, "\n") {
+	for line := range strings.SplitSeq(stdout, "\n") {
 		if !strings.HasPrefix(line, "Benchmark") {
 			continue
 		}

--- a/internal/tools/hypertest/bench.go
+++ b/internal/tools/hypertest/bench.go
@@ -241,7 +241,8 @@ func (r *benchReport) toCSV(w io.Writer) error {
 	}
 
 	indices := map[[2]int]int{}
-	header := []string{"benchmark"}
+	header := make([]string, 0, 1+len(r.columns)*len(r.subtests))
+	header = append(header, "benchmark")
 	for i, c := range r.columns {
 		for j, subtest := range r.subtests {
 			indices[[2]int{i, j}] = len(header)
@@ -249,7 +250,8 @@ func (r *benchReport) toCSV(w io.Writer) error {
 		}
 	}
 
-	cells := [][]string{header}
+	cells := make([][]string, 0, 1+len(r.benches))
+	cells = append(cells, header)
 	for _, bs := range r.benches {
 		row := make([]string, len(header))
 		cells = append(cells, row)

--- a/internal/tools/hypertest/exec.go
+++ b/internal/tools/hypertest/exec.go
@@ -219,9 +219,7 @@ func (r *runner) runOverSSH(remote string, tests []test) (string, error) {
 	wg := new(sync.WaitGroup)
 	syncErr := new(atomic.Pointer[error])
 	for _, test := range tests {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			{
 				start := time.Now()
 				src, err := os.Open(test.binary(r, ""))
@@ -249,7 +247,7 @@ func (r *runner) runOverSSH(remote string, tests []test) (string, error) {
 			}
 		error:
 			syncErr.CompareAndSwap(nil, &err)
-		}()
+		})
 	}
 	wg.Wait()
 	if err := syncErr.Load(); err != nil {

--- a/internal/xsync/atomic.go
+++ b/internal/xsync/atomic.go
@@ -38,8 +38,8 @@ func (x *AtomicFloat64) Swap(val float64) (old float64) {
 	return math.Float64frombits((*atomic.Uint64)(x).Swap(math.Float64bits(val)))
 }
 
-// Swap atomically stores the given float64 if x currently holds a float with
-// the same bit-pattern as val.
+// BitwiseCompareAndSwap atomically stores new if x currently holds a float
+// with the same bit-pattern as old.
 //
 // That is to say, this does *not* perform a floating-point comparison!
 func (x *AtomicFloat64) BitwiseCompareAndSwap(old, new float64) (swapped bool) {

--- a/internal/xunsafe/addr.go
+++ b/internal/xunsafe/addr.go
@@ -64,7 +64,7 @@ func (a Addr[T]) ByteAdd(n int) Addr[T] {
 	return a + Addr[T](n)
 }
 
-// Add adds the given offset to this address.
+// Sub computes the difference between two addresses, in units of T's size.
 func (a Addr[T]) Sub(b Addr[T]) int {
 	return int(a-b) / layout.Size[T]()
 }
@@ -75,7 +75,7 @@ func (a Addr[T]) Padding(align int) int {
 	return layout.Padding(int(a), align)
 }
 
-// RoundUp rounds this address upwards to align, which must be a power of two.
+// RoundUpTo rounds this address upwards to align, which must be a power of two.
 func (a Addr[T]) RoundUpTo(align int) Addr[T] {
 	return Addr[T](layout.RoundUp(uintptr(a), uintptr(align)))
 }

--- a/internal/xunsafe/layout/layout.go
+++ b/internal/xunsafe/layout/layout.go
@@ -34,12 +34,12 @@ func Size[T any]() int {
 	return int(unsafe.Sizeof(z))
 }
 
-// Size returns T's size in bits.
+// Bits returns T's size in bits.
 func Bits[T any]() int {
 	return Size[T]() * 8
 }
 
-// Size returns T's alignment in bytes.
+// Align returns T's alignment in bytes.
 func Align[T any]() int {
 	var z T
 	return int(unsafe.Alignof(z))
@@ -66,7 +66,7 @@ func RoundDown[T Int](v, align T) T {
 	return v &^ (align - 1)
 }
 
-// RoundDown rounds v up to a power of two.
+// RoundUp rounds v up to a power of two.
 func RoundUp[T Int](v, align T) T {
 	return (v + align - 1) &^ (align - 1)
 }

--- a/internal/xunsafe/untyped.go
+++ b/internal/xunsafe/untyped.go
@@ -34,7 +34,7 @@ func ByteAdd[T any, P ~*E, E any, I Int](p P, n I) *T {
 	return (*T)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + uintptr(n)))
 }
 
-// Sub computes the difference between two pointers, without scaling.
+// ByteSub computes the difference between two pointers, without scaling.
 func ByteSub[P1 ~*E1, P2 ~*E2, E1, E2 any](p1 P1, p2 P2) int {
 	return int(uintptr(unsafe.Pointer(p1)) - uintptr(unsafe.Pointer(p2)))
 }
@@ -44,7 +44,7 @@ func ByteLoad[T any, P ~*E, E any, I Int](p P, n I) T {
 	return *ByteAdd[T](p, n)
 }
 
-// ByteLoad stores a value of the given type at the given byte offset.
+// ByteStore stores a value of the given type at the given byte offset.
 func ByteStore[T any, P ~*E, E any, I Int](p P, n I, v T) {
 	*ByteAdd[T](p, n) = v
 }

--- a/internal/xunsafe/untyped.go
+++ b/internal/xunsafe/untyped.go
@@ -31,7 +31,7 @@ import "unsafe"
 //
 //go:nocheckptr
 func ByteAdd[T any, P ~*E, E any, I Int](p P, n I) *T {
-	return (*T)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + uintptr(n)))
+	return (*T)(unsafe.Add(unsafe.Pointer(p), n))
 }
 
 // ByteSub computes the difference between two pointers, without scaling.

--- a/internal/xunsafe/vla.go
+++ b/internal/xunsafe/vla.go
@@ -48,7 +48,7 @@ func (a *VLA[T]) Get(n int) *T {
 	return Add(Cast[T](a), n)
 }
 
-// Get returns a pointer to the element of this array at the given byte offset.
+// ByteGet returns a pointer to the element of this array at the given byte offset.
 func (a *VLA[T]) ByteGet(n int) *T {
 	return ByteAdd[T](a, n)
 }

--- a/internal/xunsafe/xunsafe.go
+++ b/internal/xunsafe/xunsafe.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package unsafe provides a more convenient interface for performing unsafe
+// Package xunsafe provides a more convenient interface for performing unsafe
 // operations than Go's built-in package unsafe.
 package xunsafe
 

--- a/internal/zc/zc.go
+++ b/internal/zc/zc.go
@@ -89,7 +89,7 @@ type ExtractFrom struct {
 	Src *byte
 }
 
-// ExtractBytes returns a func that calls [Range.Bytes].
+// Bytes calls [Range.Bytes] on the given raw range.
 //
 // This exists to work around inlining failure in certain places in the parser.
 func (e ExtractFrom) Bytes(raw uint64) []byte {


### PR DESCRIPTION
- Increase minimum Go to 1.25
- Add Go 1.26 to CI
- Update golangci-lint to support Go 1.26
- Address lint warnings that were a result of the golangci-lint update.